### PR TITLE
Fixed lang and scoped css

### DIFF
--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -51,7 +51,7 @@ module.exports = {
 
         // Typescript Rules
         '@typescript-eslint/camelcase': ['off'],
-        '@typescript-eslint/no-unused-vars': ['off'], // Until Volar has support for Script Setup sugar
+        '@typescript-eslint/no-unused-vars': ['off'], // Handled by tsconfig noUnusedLocals
         '@typescript-eslint/explicit-function-return-type': ['error'],
     }
 };

--- a/src/components/GlobalNav.vue
+++ b/src/components/GlobalNav.vue
@@ -6,9 +6,7 @@
     </nav>
 </template>
 
-<!-- FIXME: @apply rules are being identified as horribly incorrect CSS. Probably want to adjust the rules. -->
-<!-- TODO: Determine whether it's a best practice to style child elements, or to style the element being passed in itself -->
-<style>
+<style lang="postcss" scoped>
 a {
     @apply px-3 py-2 rounded-full text-gray-400 items-center justify-center hover:bg-black hover:bg-opacity-80 hover:text-white;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,8 @@
         "sourceMap": true,
         "lib": ["esnext", "dom"],
         "types": ["node", "vite/client"],
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
     },
     "include": [
         "src/**/*.ts",


### PR DESCRIPTION
`scoped` zorgt ervoor dat de style alleen in component en children werkt (via uniek attribute).

Erros zijn nu gefixt omdat Tailwind in postcss is, dus lang naar postcss zetten